### PR TITLE
Fix psr/http-message-shim compatibility with Joomla 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "psr/container": "1.1.2",
     "psr/event-dispatcher": "1.0.0",
     "psr/log": "3.0.1",
-    "psr/http-message": "1.1",
+    "psr/http-message": "1.1 || 2.0",
     "symfony/console": "v6.4.11",
     "symfony/deprecation-contracts": "v3.5.0",
     "symfony/event-dispatcher": "v6.4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c33e7605c213cb0b399613a15fe02c11",
+    "content-hash": "2f8bb8fad86e7b01af2a941b43e40603",
     "packages": [
         {
             "name": "mpdf/mpdf",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d22f8d9cb6776aaf148db9a5cb3c67f",
+    "content-hash": "c33e7605c213cb0b399613a15fe02c11",
     "packages": [
         {
             "name": "mpdf/mpdf",
@@ -89,20 +89,20 @@
         },
         {
             "name": "mpdf/psr-http-message-shim",
-            "version": "1.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mpdf/psr-http-message-shim.git",
-                "reference": "3206e6b80b6d2479e148ee497e9f2bebadc919db"
+                "reference": "f25a0153d645e234f9db42e5433b16d9b113920f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mpdf/psr-http-message-shim/zipball/3206e6b80b6d2479e148ee497e9f2bebadc919db",
-                "reference": "3206e6b80b6d2479e148ee497e9f2bebadc919db",
+                "url": "https://api.github.com/repos/mpdf/psr-http-message-shim/zipball/f25a0153d645e234f9db42e5433b16d9b113920f",
+                "reference": "f25a0153d645e234f9db42e5433b16d9b113920f",
                 "shasum": ""
             },
             "require": {
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^2.0"
             },
             "type": "library",
             "autoload": {
@@ -131,9 +131,9 @@
             "description": "Shim to allow support of different psr/message versions.",
             "support": {
                 "issues": "https://github.com/mpdf/psr-http-message-shim/issues",
-                "source": "https://github.com/mpdf/psr-http-message-shim/tree/1.0.0"
+                "source": "https://github.com/mpdf/psr-http-message-shim/tree/v2.0.1"
             },
-            "time": "2023-09-01T05:59:47+00:00"
+            "time": "2023-10-02T14:34:03+00:00"
         },
         {
             "name": "mpdf/psr-log-aware-trait",


### PR DESCRIPTION
Change replace.psr/http-message from 1.1 to 2.0 in composer.json Update mpdf/psr-http-message-shim from v1.0.0 to v2.0.1 in composer.lock

shim v2.0.1 adds covariant return types to Request/Response/Stream/Uri, making it compatible with psr/http-message v1.1 (used by Joomla 6). On Joomla 5 (psr/http-message v1.0), shim is replaced by Joomla's bundled version via the replace directive.

---

Исправление совместимости psr/http-message-shim с Joomla 6

Изменён replace.psr/http-message с 1.1 на 2.0 в composer.json Обновлён mpdf/psr-http-message-shim с v1.0.0 до v2.0.1 в composer.lock

shim v2.0.1 добавляет ковариантные типы возвращаемых значений для Request/Response/Stream/Uri, что делает его совместимым с psr/http-message v1.1 (используется в Joomla 6).
На Joomla 5 (psr/http-message v1.0) shim заменяется на встроенный вариант Joomla через секцию replace.